### PR TITLE
ajustei a imagem para tirar o scroll

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -5,38 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>animaçao de Goku. html</title>
-    <style>
-           
-        body{
-            background-image: url(imagens/cidade3.jpg);
-            background-size: 1350px;
-            background-repeat: no-repeat;
-                       
-        }
-
-        *{
-            margin: 0px;
-             }
-
-        .gokubr{
-            width: 10px;
-            background-color: wheat;
-            height: 5%;
-        }
-        img{
-            top: 700px;
-            left: -400px;
-            position: absolute;
-            animation-name: correr;
-            animation-duration: 6s;
-            animation-iteration-count: infinite;
-        }
-        
-        @keyframes correr{
-            form{transform: translateX(100%);}
-            100%{transform: translateX(300%);}
-        }
-    </style>
+    <link rel="stylesheet" href="style.css">
+    <!-- Adicionei o link do css para ficar mais organizado -->
 </head>
 <body>
     <img src="imagens/goku12.gif" alt="imagens.gif">

--- a/style.css
+++ b/style.css
@@ -1,0 +1,34 @@
+*{
+    margin: 0px;
+}
+
+/* Ajeitei a imagem para ficar toda na tela */
+/* dessa forma não tem mais efeito de scroll pra baixo */
+body{
+    background-image: url(imagens/cidade3.png);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-size: cover;
+    background-position: center center;
+}
+
+.gokubr{
+    width: 10px;
+    background-color: wheat;
+    height: 5%;
+}
+
+/* Fiz o goku se posicionar pelo bottom com 3vh (3% de altura total da tela) */
+img{
+    bottom: 3vh;
+    left: -400px;
+    position: absolute;
+    animation-name: correr;
+    animation-duration: 6s;
+    animation-iteration-count: infinite;
+}
+
+@keyframes correr{
+    form{transform: translateX(100%);}
+    100%{transform: translateX(322%);}
+}


### PR DESCRIPTION
Olá tudo bem? desculpa o incomodo, eu estava vendo repositórios no github e achei o seu bem legal, só que notei um problema (não sei se era só na minha máquina) que a imagem tava muito grande tendo que da scroll pra baixo para poder ver a animação.

Resolvi o problema 
. trocando a imagem pela aquela do png,
. ajustando de onde o goku começava a andar (sua altura de acordo com o bottom),
. usando `background-size: cover` (fica do tamanho da tela).

Espero ter ajudado! Ficou bem legal seu repositório.